### PR TITLE
add requestId via cls-rTracer to outbound request(s) headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,10 +103,9 @@ function mergeOptions(baseOptions, newOptions) {
 	const resolvedNewOptions = newOptions || {};
 	const headers = objectAssign({}, baseOptions.headers, resolvedNewOptions.headers);
 
-	const reqID = rTracer.id()?? null;
-	if (reqID != null) {
+	const reqID = rTracer.id() ?? null;
+	if (reqID !== null)
 		headers = objectAssign({}, headers, { 'request-id': reqID })
-	}
 
 	return objectAssign({}, baseOptions, newOptions, {
 		headers: headers,

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const fetchPonyfill = require('fetch-ponyfill');
 const objectAssign = require('es6-object-assign').assign;
 const qs = require('qs');
 const url = require('url');
+const rTracer = require('cls-rtracer');
 
 const { fetch } = fetchPonyfill();
 
@@ -19,7 +20,7 @@ function jsonClient(baseUrl, options) {
 
 	return function jsonClientRequest(method, path, params, body, options) {
 		const query = params ? '?' + qs.stringify(params) : '';
-		const resolved = url.resolve(resolvedBaseUrl, path + query);
+		const resolved = new url(path + query, resolvedBaseUrl);
 		const reqOptions = mergeOptions(baseOptions, options);
 
 		return makeRequest(method, resolved, body, reqOptions);
@@ -101,6 +102,11 @@ function makeRequest(method, fullUrl, body, options) {
 function mergeOptions(baseOptions, newOptions) {
 	const resolvedNewOptions = newOptions || {};
 	const headers = objectAssign({}, baseOptions.headers, resolvedNewOptions.headers);
+
+	const reqID = rTracer.id()?? null;
+	if (reqID != null) {
+		headers = objectAssign({}, headers, { 'request-id': reqID })
+	}
 
 	return objectAssign({}, baseOptions, newOptions, {
 		headers: headers,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "git+https://github.com/cuvva/json-client.git"
   },
   "dependencies": {
+    "cls-rtracer": "^2.6.0",
     "es6-object-assign": "^1.1.0",
     "fetch-ponyfill": "^7.1.0",
     "qs": "^6.5.2",


### PR DESCRIPTION
## Ticket

- non-public

## Goal / Context

- as part of improving our developer(s) experience(s), we're increasing the traceability of requests made through our nodesJS services. This change will help us to trace requests from A to Z across our systems.

## Extra

- replace deprecated method `resolve` by `url` constructor