### PR TITLE
add request id to error meta

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ function makeRequest(method, fullUrl, body, options) {
 				method: method,
 				url: fullUrl,
 				data: body,
-				requestId: response.headers['request-id'] ?? '',
+				requestId: response.headers['request-id'] ?? void 0,
 			};
 
 			try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ function makeRequest(method, fullUrl, body, options) {
 						method: method,
 						url: fullUrl,
 						data: body,
-						requestId: response.headers['request-id'] ?? '',
+						requestId: response.headers['request-id'] ?? void 0,
 					};
 
 					throw error;

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ function makeRequest(method, fullUrl, body, options) {
 				method: method,
 				url: fullUrl,
 				data: body,
-				requestID: response.headers['request-id'] ?? '',
+				requestId: response.headers['request-id'] ?? '',
 			};
 
 			try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ function makeRequest(method, fullUrl, body, options) {
 						method: method,
 						url: fullUrl,
 						data: body,
-						requestID: response.headers['request-id'] ?? '',
+						requestId: response.headers['request-id'] ?? '',
 					};
 
 					throw error;

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,13 @@ function makeRequest(method, fullUrl, body, options) {
 
 					error.code = 'invalid_json';
 					error.statusCode = code;
-					error.meta = { httpStatus: code, method: method, url: fullUrl, data: body };
+					error.meta = { 
+						httpStatus: code,
+						method: method,
+						url: fullUrl,
+						data: body,
+						requestID: response.headers['request-id'] ?? '',
+					};
 
 					throw error;
 				}
@@ -76,7 +82,13 @@ function makeRequest(method, fullUrl, body, options) {
 
 			error.code = codeStr;
 			error.statusCode = code;
-			error.meta = { httpStatus: code, method: method, url: fullUrl, data: body };
+			error.meta = { 
+				httpStatus: code,
+				method: method,
+				url: fullUrl,
+				data: body,
+				requestID: response.headers['request-id'] ?? '',
+			};
 
 			try {
 				const json = JSON.parse(body);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuvva/json-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple library for requesting data from JSON APIs",
   "homepage": "https://github.com/cuvva/json-client",
   "bugs": {


### PR DESCRIPTION
## Context

- Current error handling from the Dash are currently not including a precious request-id, this should add it to the output